### PR TITLE
refactored to make a little simpler

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -78,13 +78,12 @@ class Payments(ViewSet):
             return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     def list(self, request):
-        """Handle GET requests to payment type resource""" 
+        """Handle GET requests to payment type resource specific to authenticated user""" 
         current_user = request.auth.user.id 
         
         payment_types = Payment.objects.filter(customer__id=current_user)
 
         customer_id = self.request.query_params.get('customer', None)
-        # customer_id = request.auth.user
 
         if customer_id is not None:
             payment_types = payment_types.filter(customer__id=customer_id)

--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -79,9 +79,8 @@ class Payments(ViewSet):
 
     def list(self, request):
         """Handle GET requests to payment type resource specific to authenticated user""" 
-        current_user = request.auth.user.id 
         
-        payment_types = Payment.objects.filter(customer__id=current_user)
+        payment_types = Payment.objects.filter(customer__id=request.auth.user.id)
 
         customer_id = self.request.query_params.get('customer', None)
 

--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -1,5 +1,4 @@
 """View module for handling requests about customer payment types"""
-import re
 from django.http import HttpResponseServerError
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response

--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -1,4 +1,5 @@
 """View module for handling requests about customer payment types"""
+import re
 from django.http import HttpResponseServerError
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
@@ -20,7 +21,7 @@ class PaymentSerializer(serializers.HyperlinkedModelSerializer):
             lookup_field='id'
         )
         fields = ('id', 'url', 'merchant_name', 'account_number',
-                  'expiration_date', 'create_date')
+                  'expiration_date', 'create_date', 'customer_id')
 
 
 class Payments(ViewSet):
@@ -78,10 +79,13 @@ class Payments(ViewSet):
             return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     def list(self, request):
-        """Handle GET requests to payment type resource"""
-        payment_types = Payment.objects.all()
+        """Handle GET requests to payment type resource""" 
+        current_user = request.auth.user.id 
+        
+        payment_types = Payment.objects.filter(customer__id=current_user)
 
         customer_id = self.request.query_params.get('customer', None)
+        # customer_id = request.auth.user
 
         if customer_id is not None:
             payment_types = payment_types.filter(customer__id=customer_id)


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- added `customer_id` in serializer to more easily observe accuracy of results
- changed the `list` function in `paymenttypes.py` to filter on the current auth user's id rather than getting all `Payment` objects

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

GET `/paymenttypes` returns only the authenticated user's payment information. In this case, the token I was using belonged to customer 5.

```json
{
    "model": "bangazonapi.payment",
    "pk": 1,
    "fields": {
        "merchant_name": "Visa",
        "account_number": "24ijio68948fj8439",
        "customer_id": "5",
        "expiration_date": "2020-01-01",
        "create_date": "2019-11-11"
    }
}
```

**Response**

HTTP/1.1 200 OK

```json
{
    "id": 1,
    "url": "http://localhost:8000/paymenttypes/1",
    "merchant_name": "Visa",
    "account_number": "24ijio68948fj8439",
    "expiration_date": "2020-01-01",
    "create_date": "2019-11-11",
    "customer_id": 5
}
```

## Testing


- [ ] Select the "Get all payment types" request from the sidebar navigation within the Bangazon Python API in Postman
- [ ] Send the request
- [ ] Make sure there is a token inserted on the Headers tab
- [ ] The current seed database only has one payment type per user, so no matter your token, Postman should return only one result.
- [ ] Test with a new token belonging to another account to ensure you still get a different, single result

## Related Issues

- Fixes #8 
