### PR TITLE
fix average_rating to work correctly

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -63,12 +63,11 @@ class Product(SafeDeleteModel):
             #sum of all the product ratings
             total_rating = 0
             for rating in ratings:
-                total_rating += rating.score
+                total_rating += rating.rating
             # Calculate the averge and return it.
             avg = total_rating / len(ratings)
             return avg
 
-        #else:
         return 0
 
 

--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -58,12 +58,19 @@ class Product(SafeDeleteModel):
             number -- The average rating for the product
         """
         ratings = ProductRating.objects.filter(product=self)
-        total_rating = 0
-        for rating in ratings:
-            total_rating += rating.rating
 
-        avg = total_rating / len(ratings)
-        return avg
+        if len(ratings):
+            #sum of all the product ratings
+            total_rating = 0
+            for rating in ratings:
+                total_rating += rating.score
+            # Calculate the averge and return it.
+            avg = total_rating / len(ratings)
+            return avg
+
+        #else:
+        return 0
+
 
     class Meta:
         verbose_name = ("product")


### PR DESCRIPTION
## Changes

- In `product.py`, added an if statement to return 0 as an alternative if there are no ratings yet on a product 


## Requests / Responses

**Request**

GET `/products` returns all products. Singular example here:

```json
{
        "model": "bangazonapi.product",
        "pk": 50,
        "fields": {
            "name": "Escalade EXT",
            "customer_id": 4,
            "price": 926.92,
            "description": "2008 Cadillac",
            "quantity": 2,
            "created_date": "2019-02-01",
            "category_id": 2,
            "location": "Lokavec",
            "image_path": ""
        }
   },
```

**Response**

HTTP/1.1 200 OK

```json
{
    "id": 50,
    "name": "Escalade EXT",
    "price": 926.92,
    "number_sold": 2,
    "description": "2008 Cadillac",
    "quantity": 2,
    "created_date": "2019-02-01",
    "location": "Lokavec",
    "image_path": null,
    "average_rating": 3.25
}
```

## Testing

- [ ] In the Bangazon Python API Postman, select the "Get all products" request from the sidebar navigation and hit Send
- [ ] Confirm that the division by zero error is gone and that a list of products is returned
- [ ] Run the same test for /products/1 to confirm that the request works for a single product as well


## Related Issues

- Fixes #11 
