### PR TITLE
removed duplicate lineitems returning

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -156,7 +156,6 @@ class Profile(ViewSet):
 
                 cart = {}
                 cart["order"] = OrderSerializer(open_order, many=False, context={'request': request}).data
-                cart["order"]["line_items"] = line_items.data
                 cart["order"]["size"] = len(line_items.data)
 
 


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- In `profile.py`, removed the line of code that was returning `line_items` objects, thereby removing the duplicates

## Requests / Responses

**Request**

GET `/profile/cart` returns profile and current cart information

```json
{
    "id": 2,
    "url": "http://localhost:8000/orders/2",
    "created_date": "2019-04-12",
    "payment_type": null,
    "customer": "http://localhost:8000/customers/7",
    "lineitems": [ ],
    "size": 3
}
```

**Response**

HTTP/1.1 200 OK

```json
{
    "id": 2,
    "url": "http://localhost:8000/orders/2",
    "created_date": "2019-04-12",
    "payment_type": null,
    "customer": "http://localhost:8000/customers/7",
    "lineitems": [
        {
            "id": 4,
            "product": {
                "id": 52,
                "name": "900",
                "price": 1296.98,
                "number_sold": 0,
                "description": "1987 Saab",
                "quantity": 2,
                "created_date": "2019-03-19",
                "location": "Vratsa",
                "image_path": null,
                "average_rating": 0
            }
        },
        {
            "id": 5,
            "product": {
                "id": 33,
                "name": "Stratus",
                "price": 1199.91,
                "number_sold": 0,
                "description": "2001 Dodge",
                "quantity": 1,
                "created_date": "2019-04-06",
                "location": "Tianning",
                "image_path": null,
                "average_rating": 0
            }
        },
        {
            "id": 6,
            "product": {
                "id": 71,
                "name": "Sebring",
                "price": 1045.66,
                "number_sold": 0,
                "description": "1999 Chrysler",
                "quantity": 4,
                "created_date": "2019-05-18",
                "location": "Namibe",
                "image_path": null,
                "average_rating": 0
            }
        }
    ],
    "size": 3
}
```

## Testing

Description of how to test code...

- [ ] In the Bangazon Python API in Postman, select the Shopping cart GET request and hit Send
- [ ] Confirm that only objects for `lineitems` are returning, nothing for `line_items`


## Related Issues

- Fixes #2 
