### PR TITLE
returns current user's profile

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -61,7 +61,7 @@ class Profile(ViewSet):
             }
         """
         try:
-            current_user = Customer.objects.get(user__id=4)
+            current_user = Customer.objects.get(user__id=request.auth.user.id)
             serializer = ProfileSerializer(current_user, many=False, context={'request': request})
             return Response(serializer.data)
         except Exception as ex:


### PR DESCRIPTION
## Changes

- User id was hardcoded in `profile.py` - changed it to the be the id of auth user

## Requests / Responses

**Request**

GET `/profile` returns logged-in user's profile information

```json
{
    "model": "bangazonapi.customer",
    "pk": 4,
    "fields": {
        "user": 5,
        "phone_number": "555-1212",
        "address": "100 Infinity Way"
    }
},
```

**Response**

HTTP/1.1 200 OK

```json
{
    "id": 4,
    "url": "http://localhost:8000/customers/4",
    "user": {
        "first_name": "Steve",
        "last_name": "Brownlee",
        "email": "steve@stevebrownlee.com"
  },
    "phone_number": "555-1212",
    "address": "100 Infinity Way",
    "payment_types": []
}
```

## Testing

- [ ] In the Bangazon Python API in Postman, select the User profile request under Profile in the side navigation and hit Send
- [ ] Confirm that the previous error message has been replaced with data for the user matching the auth token
- [ ] Change the token and run the test again to confirm that a different user's profile returns

## Related Issues

- Fixes #4 