### PR TITLE
returns correct results for query

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -17,7 +17,7 @@ class ProductSerializer(serializers.ModelSerializer):
         model = Product
         fields = ('id', 'name', 'price', 'number_sold', 'description',
                   'quantity', 'created_date', 'location', 'image_path',
-                  'average_rating', 'can_be_rated', )
+                  'average_rating', 'can_be_rated', 'category')
         depth = 1
 
 
@@ -266,11 +266,12 @@ class Products(ViewSet):
 
         if number_sold is not None:
             def sold_filter(product):
-                if product.number_sold <= int(number_sold):
+                if product.number_sold >= int(number_sold):
                     return True
                 return False
 
             products = filter(sold_filter, products)
+
 
         serializer = ProductSerializer(
             products, many=True, context={'request': request})


### PR DESCRIPTION
## Changes

- Changed from <= to >= in `product.py` viewset so that it doesn't return less than the number requested

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

GET http://localhost:8000/products?number_sold=2 returns the one item in the data that's been sold at least twice

```json
{
      "model": "bangazonapi.product",
      "pk": 50,
      "fields": {
          "name": "Escalade EXT",
          "customer_id": 4,
          "price": 926.92,
          "description": "2008 Cadillac",
          "quantity": 2,
          "created_date": "2019-02-01",
          "category_id": 2,
          "location": "Lokavec",
          "image_path": ""
      }
  },
```

**Response**

HTTP/1.1 200 OK

```json
[
    {
        "id": 50,
        "name": "Escalade EXT",
        "price": 926.92,
        "number_sold": 2,
        "description": "2008 Cadillac",
        "quantity": 2,
        "created_date": "2019-02-01",
        "location": "Lokavec",
        "image_path": null,
        "average_rating": 3.25,
        "category": {
            "id": 2,
            "name": "Auto"
        }
    }
]
```

## Testing

Description of how to test code...

- [ ] In the Bangazon Python API in Postman, select the "Products that have sold 2 or more" request and hit Send
- [ ] Based on the seed data, only one result should return
- [ ] Change the number in the URL to 3 or greater and run the test to confirm that no results return


## Related Issues

- Fixes #5 
