### PR TITLE
line items delete from cart

### DIFF
--- a/bangazonapi/views/lineitem.py
+++ b/bangazonapi/views/lineitem.py
@@ -36,7 +36,7 @@ class LineItems(ViewSet):
 
     def retrieve(self, request, pk=None):
         """
-        @api {GET} /cart/:id GET line item from cart
+        @api {GET} /lineitems/:id GET line item from cart
         @apiName GetLineItem
         @apiGroup ShoppingCart
 
@@ -44,9 +44,9 @@ class LineItems(ViewSet):
         @apiHeaderExample {String} Authorization
             Token 9ba45f09651c5b0c404f37a2d2572c026c146611
 
-        @apiParam {id} id Product Id to get from cart
+        @apiParam {id} id LineItem (order_product) Id to get from cart
         @apiSuccessExample {json} Success
-            HTTP/1.1 204 No Content
+            HTTP/1.1 200 OK
         """
         try:
             customer = Customer.objects.get(user=request.auth.user)
@@ -61,7 +61,7 @@ class LineItems(ViewSet):
 
     def destroy(self, request, pk=None):
         """
-        @api {DELETE} /cart/:id DELETE line item from cart
+        @api {DELETE} /lineitems/:id DELETE line item from cart
         @apiName RemoveLineItem
         @apiGroup ShoppingCart
 
@@ -69,7 +69,7 @@ class LineItems(ViewSet):
         @apiHeaderExample {String} Authorization
             Token 9ba45f09651c5b0c404f37a2d2572c026c146611
 
-        @apiParam {id} id Product Id to remove from cart
+        @apiParam {id} id LineItem (order_product) Id to remove from cart
         @apiSuccessExample {json} Success
             HTTP/1.1 204 No Content
         """

--- a/bangazonapi/views/lineitem.py
+++ b/bangazonapi/views/lineitem.py
@@ -36,20 +36,19 @@ class LineItems(ViewSet):
 
     def retrieve(self, request, pk=None):
         """
-        @api {GET} /cart/:id DELETE line item from cart
-        @apiName RemoveLineItem
+        @api {GET} /cart/:id GET line item from cart
+        @apiName GetLineItem
         @apiGroup ShoppingCart
 
         @apiHeader {String} Authorization Auth token
         @apiHeaderExample {String} Authorization
             Token 9ba45f09651c5b0c404f37a2d2572c026c146611
 
-        @apiParam {id} id Product Id to remove from cart
+        @apiParam {id} id Product Id to get from cart
         @apiSuccessExample {json} Success
             HTTP/1.1 204 No Content
         """
         try:
-            # line_item = OrderProduct.objects.get(pk=pk)
             customer = Customer.objects.get(user=request.auth.user)
             line_item = OrderProduct.objects.get(pk=pk, order__customer=customer)
 
@@ -77,6 +76,7 @@ class LineItems(ViewSet):
         try:
             customer = Customer.objects.get(user=request.auth.user)
             order_product = OrderProduct.objects.get(pk=pk, order__customer=customer)
+            order_product.delete()
 
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 


### PR DESCRIPTION
## Changes

- Added `order_product.delete()` in `lineitem.py` so that the record would actually delete
- Updated docstring content for the `retrieve` function to be accurate since it looked like the delete's docstring
- Updated docstring content for the `destroy` function to refer to `lineitems` rather than carts and products

## Requests / Responses

**Request**

N/A

**Response**

HTTP/1.1 204 No Content

```json
{}
```

## Testing

- [ ] In the Python Bangazon API in Postman, first perform a GET request on an existing line item, such as http://localhost:8000/lineitems/5, to confirm that the record exists
- [ ] Change the GET to DELETE and hit Send
- [ ] Confirm that you get an empty result and a 204 No Content result
- [ ] Change back to a GET request and confirm that the record no longer exists


## Related Issues

- Fixes #6 
