### PR TITLE
payment types created with correct dates

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -34,8 +34,8 @@ class Payments(ViewSet):
         new_payment = Payment()
         new_payment.merchant_name = request.data["merchant_name"]
         new_payment.account_number = request.data["account_number"]
-        new_payment.expiration_date = request.data["create_date"]
-        new_payment.create_date = request.data["expiration_date"]
+        new_payment.expiration_date = request.data["expiration_date"]
+        new_payment.create_date = request.data["create_date"]
         customer = Customer.objects.get(user=request.auth.user)
         new_payment.customer = customer
         new_payment.save()


### PR DESCRIPTION
## Changes

- In the `paymenttype.py viewset`, the `expiration_date` and `create_date` data were on the wrong lines in the create function. Swapped them so that they were belonging to the correct variables

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

POST `/paymenttypes` Creates a new payment type

```json
{
    "merchant_name": "Amex",
    "account_number": "000000000000",
    "expiration_date": "2023-12-12",
    "create_date": "2020-12-12"
}
```

**Response**

HTTP/1.1 201 Created

```json
{
    "id": 5,
    "url": "http://localhost:8000/paymenttypes/5",
    "merchant_name": "Amex",
    "account_number": "000000000000",
    "expiration_date": "2023-12-12",
    "create_date": "2020-12-12",
    "customer_id": 4
}
```

## Testing

Description of how to test code...

- [ ] In the Bangazon Python API, select the "Create a payment type request", change the dates if you would like, and hit send
- [ ] Previously, the expiration date was returning as the creation date, and vice versa
- [ ] Observe the results to confirm that the expiration date in the response is the later date and matches the data you entered for the expiration date when you created the new payment type


## Related Issues

- Fixes #85
- Fixes #22