### PR TITLE
fixed items that were adding to closed orders

### DIFF
--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -104,7 +104,7 @@ class Orders(ViewSet):
         """
         customer = Customer.objects.get(user=request.auth.user)
         order = Order.objects.get(pk=pk, customer=customer)
-        order.payment_type = request.data["payment_type"]
+        order.payment_type = Payment.objects.get(pk=request.data["payment_type"])
         order.save()
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -206,7 +206,7 @@ class Profile(ViewSet):
             """
 
             try:
-                open_order = Order.objects.get(customer=current_user)
+                open_order = Order.objects.get(customer=current_user, payment_type__isnull=True)
                 print(open_order)
             except Order.DoesNotExist as ex:
                 open_order = Order()


### PR DESCRIPTION
## Changes

- Changed `update` function in `order.py` to accept payment type instance on open order so that the order could be closed
- Added a check for null payment type on orders in `profile.py` in the `try` so that a new order would be created if the payment type is not null

## Requests / Responses

N/A

## Testing

- [ ] In the Bangazon Python API in Postman, follow the original reproduction steps from this ticket: 
1. Authenticate the client and get a token
2. Create a payment type
3. Add a product to the cart by sending a POST request to http://localhost:8000/profile/cart
4. Finish the order by sending a PUT request to the order's URL
5. Add a product to the cart by sending a POST request to http://localhost:8000/profile/cart
- [ ] Perform a GET request on http://localhost:8000/profile/cart and see that a result comes back with a new order that has a null payment type and only contains the new item you just added.


## Related Issues

- Fixes #3 
