### PR TITLE
can query by minimum product price

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -242,12 +242,13 @@ class Products(ViewSet):
         """
         products = Product.objects.all()
 
-        # Support filtering by category and/or quantity
+        # Support filtering by category, price or quantity
         category = self.request.query_params.get('category', None)
         quantity = self.request.query_params.get('quantity', None)
         order = self.request.query_params.get('order_by', None)
         direction = self.request.query_params.get('direction', None)
         number_sold = self.request.query_params.get('number_sold', None)
+        price = self.request.query_params.get('min_price', None)
 
         if order is not None:
             order_filter = order
@@ -271,6 +272,14 @@ class Products(ViewSet):
                 return False
 
             products = filter(sold_filter, products)
+
+        if price is not None:
+            def price_filter(product):
+                if product.price >= float(price):
+                    return True
+                return False
+
+            products = filter(price_filter, products)       
 
 
         serializer = ProductSerializer(


### PR DESCRIPTION
## Changes

- Added a query parameter for price in `product.py` and updated comment to reflect
- Added an `if` statement similar to the one for `number_sold` to filter through the prices and return those that matched or were greater than the float value of the price queried

## Requests / Responses

N/A

## Testing

Description of how to test code...

- [ ] In the Bangazon Python API in Postman, run a GET request with the URL http://localhost:8000/products?min_price=1500
- [ ] Verify that the objects in the response all have a price that is at least 1500
- [ ] Run the test again with a higher price, such as 1800, and confirm that a fewer number of objects are returning in the response, all with a price of at least 1800.


## Related Issues

- Fixes #85
- Fixes #22