### PR TITLE
increased max value validator for product price

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -15,7 +15,7 @@ class Product(SafeDeleteModel):
     customer = models.ForeignKey(
         Customer, on_delete=models.DO_NOTHING, related_name='products')
     price = models.FloatField(
-        validators=[MinValueValidator(0.00), MaxValueValidator(10000.00)],)
+        validators=[MinValueValidator(0.00), MaxValueValidator(17500.00)],)
     description = models.CharField(max_length=255,)
     quantity = models.IntegerField(validators=[MinValueValidator(0)],)
     created_date = models.DateField(auto_now_add=True)


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- Changed the `MaxValueValidator` in the `product.py` model from 10,000 to 17,500 and redid the migrations

## Requests / Responses

N/A

## Testing

Description of how to test code...

- [ ] In the Bangazon Python API in Postman, open up one of the Create Product POST tests. Create a product with a price in between 10,000 and 17,500.
- [ ] Confirm that the item is successfully created with no error messages
- [ ] Run the same test with the other Create Product POST test to confirm that both of them work.


## Related Issues

- Fixes #10 