### PR TITLE
passed test to delete products

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -162,8 +162,11 @@ class Products(ViewSet):
             product = Product.objects.get(pk=pk)
             serializer = ProductSerializer(product, context={'request': request})
             return Response(serializer.data)
+        except Product.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+
         except Exception as ex:
-            return HttpResponseServerError(ex)
+            return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     def update(self, request, pk=None):
         """

--- a/tests/product.py
+++ b/tests/product.py
@@ -1,3 +1,4 @@
+from bangazonapi.models.product import Product
 import json
 import datetime
 from rest_framework import status
@@ -95,6 +96,29 @@ class ProductTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(json_response), 3)
 
-    # TODO: Delete product
+    def test_delete_product(self):
+        """
+        Ensure we can delete an existing product.
+        """       
+
+        product = Product()
+        product.name = "Soccer ball"
+        product.customer_id = 1
+        product.price = 10
+        product.description = "Round and kickable"
+        product.quantity = 5
+        product.category_id = 1
+        product.location = "Chicago"
+        product.save()
+
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.delete(f"/products/{product.id}")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # GET PRODUCT AGAIN TO VERIFY 404 response
+        response = self.client.get(f"/products/{product.id}")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
 
     # TODO: Product can be rated. Assert average rating exists.


### PR DESCRIPTION
## Changes

- Added test to delete a product in the `product.py` file in the test folder
- Changed the exception error on the retrieve function for products to satisfy the test's check for a 404 error on the deleted product

## Requests / Responses

OK

## Testing

Description of how to test code...

- [ ] In a virtual environment, run `python manage.py test tests -v 1` in your terminal to confirm that the test passes


## Related Issues

- Fixes #18 